### PR TITLE
Added number of connected nodes to Overview page

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -71,6 +71,7 @@ body {
   font-size: 16px;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 1.0), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
   border-radius: 10px;
+  padding-bottom: 20px;
   height: 100%;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,6 +30,7 @@
         <strong>Wallet Weight:</strong> <span class="pull-right">{{'%0.8f'| format(stake_output.weight|float / 100000000)}}</span> <br />
         <strong>Net Weight:</strong> <span class="pull-right">{{'%0.2f'| format(stake_output.netstakeweight|float / 100000000000000)}} M</span> <br />
         <strong>Approx TTS:</strong> <span class="pull-right">{{ stake_time }} Days</span> <br />
+        <strong>Connections:</strong> <span class="pull-right">{{ get_current_block.connections }} Nodes</span> <br />
       </div>
     </div>
     <div class="transactions-index table-responsive col-xs-12">


### PR DESCRIPTION
From 'qtum-cli getinfo', I added the value of the connections field.  This is useful for people (like myself) to see how connected my qtum node is.  The change looks like the following:

<img width="1026" alt="image" src="https://user-images.githubusercontent.com/20646240/33237463-de0615b4-d231-11e7-8071-a587fc6791db.png">
