### PR TITLE
Fixed version string where the patch number was being truncated

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -13,7 +13,7 @@
       </div>
       <div class="wallet-right col-xs-12 col-md-6">
         <h3>Information</h3> <br />
-        <strong>Wallet Version:</strong> <span class="pull-right">{{ wallet_version[29:36] }}</span> <br />
+        <strong>Wallet Version:</strong> <span class="pull-right">{{ wallet_version[29:37] }}</span> <br />
         <strong>Current Block:</strong> <span class="pull-right">{{ get_current_block.blocks }}</span> <br />
         {% if stake_output.staking == false %}
           <strong>Staking:</strong> <span class="pull-right red-sm">{{ stake_output.staking }}</span> <br />


### PR DESCRIPTION
On the overview page, the wallet version string was being truncated (e.g.  `v0.14.10` was being displayed as `0.14.1`).  This fixes that.